### PR TITLE
Fixed AddResource to not die with a NPE

### DIFF
--- a/maven-uberize-plugin/pom.xml
+++ b/maven-uberize-plugin/pom.xml
@@ -112,6 +112,14 @@ under the License.
       <version>3.8.2</version>
       <scope>test</scope>
     </dependency>
+    
+    
+    <dependency>
+      <groupId>org.easymock</groupId>
+      <artifactId>easymock</artifactId>
+      <version>3.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/maven-uberize-plugin/src/main/java/org/fusesource/mvnplugins/uberize/transformer/AddResource.java
+++ b/maven-uberize-plugin/src/main/java/org/fusesource/mvnplugins/uberize/transformer/AddResource.java
@@ -40,7 +40,10 @@ public class AddResource implements Transformer {
 
     public void process(Uberizer uberizer, File workDir, TreeMap<String, UberEntry> uberEntries) throws IOException {
         if( file!=null && file.exists() && path!=null ) {
-            final UberEntry uberEntry = uberEntries.get(path);
+            UberEntry uberEntry = uberEntries.get(path);
+            if (uberEntry == null) {
+            	uberEntry = new UberEntry(path);
+            }
             UberEntry modEntry = new UberEntry(path, uberEntry);
             modEntry.getSources().add(file);
             modEntry.getSources().addAll(uberEntry.getSources());

--- a/maven-uberize-plugin/src/test/java/org/fusesource/mvnplugins/uberize/transformer/AddResourceTest.java
+++ b/maven-uberize-plugin/src/test/java/org/fusesource/mvnplugins/uberize/transformer/AddResourceTest.java
@@ -1,0 +1,117 @@
+package org.fusesource.mvnplugins.uberize.transformer;
+
+import static org.easymock.EasyMock.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.TreeMap;
+
+import org.fusesource.mvnplugins.uberize.UberEntry;
+import org.fusesource.mvnplugins.uberize.Uberizer;
+
+import junit.framework.TestCase;
+
+public class AddResourceTest extends TestCase {
+
+	private Uberizer mockUberizer;
+	private TreeMap<String, UberEntry> mockUberEntries;
+	private File mockWorkDir;	
+	
+	@SuppressWarnings("unchecked")
+	@Override
+	protected void setUp() throws Exception {
+		super.setUp();
+		mockUberizer = createMock(Uberizer.class);
+		mockUberEntries = (TreeMap<String, UberEntry>) createMock(TreeMap.class);
+		mockWorkDir = createMock(File.class);
+		replay(mockUberizer);
+		replay(mockUberEntries);
+		replay(mockWorkDir);
+	}
+
+	@Override
+	protected void tearDown() throws Exception {
+		super.tearDown();
+		verify(mockUberizer);
+		verify(mockUberEntries);
+		verify(mockWorkDir);
+	}
+
+	public void testProcessWithNonExistentFileDoesNothing() throws IOException {
+		AddResource transform = new AddResource();
+		File tmpFile = File.createTempFile("test", "txt");
+		tmpFile.delete();
+		assertFalse(tmpFile.exists());
+		transform.file = tmpFile;
+		transform.path = "/path/to/replace";
+		transform.process(mockUberizer, mockWorkDir, mockUberEntries);
+	}
+	
+	public void testProcessWithNullFileDoesNothing() throws IOException {
+		AddResource transform = new AddResource();
+		transform.file = null;
+		transform.path = "/path/to/replace";
+		transform.process(mockUberizer, mockWorkDir, mockUberEntries);
+	}
+
+	public void testProcessWithNullPathDoesNothing() throws IOException {
+		AddResource transform = new AddResource();
+		File tmpFile = File.createTempFile("test", "txt");
+		assertTrue(tmpFile.exists());
+		transform.file = tmpFile;
+		transform.path = null;
+		transform.process(mockUberizer, mockWorkDir, mockUberEntries);
+	}
+
+	public void testProcessAddsResourceToUberEntry() throws IOException {
+		String path = "/path/to/replace";
+		
+		UberEntry existingEntry = new UberEntry(path);
+		File existingFile = new File("/existing/file");
+		existingEntry.addSource(existingFile);
+		
+		TreeMap<String, UberEntry> uberEntries = new TreeMap<String, UberEntry>();
+		uberEntries.put(path, existingEntry);
+		
+		mockUberizer = createMock(Uberizer.class);
+		mockWorkDir = createMock(File.class);
+		replay(mockUberizer);
+		replay(mockWorkDir);
+		
+		AddResource transform = new AddResource();
+		File newFile = File.createTempFile("test", "txt");
+		transform.file = newFile;
+		transform.path = path;		
+		transform.process(mockUberizer, mockWorkDir, uberEntries);
+
+		assertEquals(1, uberEntries.size());
+		UberEntry newEntry = uberEntries.get(path);
+		assertNotSame(existingEntry, newEntry);
+		assertEquals(2, newEntry.getSources().size());
+		assertTrue(newEntry.getSources().contains(existingFile));
+		assertTrue(newEntry.getSources().contains(newFile));
+	}
+	
+	public void testProcessInitialisesUberEntryIfItIsFirstAtThatPath() throws IOException {
+		String path = "/path/to/replace";
+		
+		TreeMap<String, UberEntry> uberEntries = new TreeMap<String, UberEntry>();		
+		mockUberizer = createMock(Uberizer.class);
+		mockWorkDir = createMock(File.class);
+		replay(mockUberizer);
+		replay(mockWorkDir);
+		
+		AddResource transform = new AddResource();
+		File newFile = File.createTempFile("test", "txt");
+		transform.file = newFile;
+		transform.path = path;		
+		transform.process(mockUberizer, mockWorkDir, uberEntries);
+
+		assertEquals(1, uberEntries.size());
+		UberEntry newEntry = uberEntries.get(path);
+		assertNotNull(newEntry);
+		assertEquals(1, newEntry.getSources().size());
+		assertTrue(newEntry.getSources().contains(newFile));
+	}
+
+}


### PR DESCRIPTION
Hi, 

I've been using the uberize plugin and finding it really useful - thanks for maintaining!

Basically, I wanted to add a resource to the Uber jar, but at a path that had not previously existed in any of the source jars. The existing implementation of the AddResource transformer modified the path record to include a new resource, but as my path was new, the associated UberEntry was null.

In this commit, I modified AddResource to avoid this scenario, by creating a new UberEntry when required.

I've also added a test class to cover this functionality. In order to do the testing, I added EasyMock to the pom. I'm happy to convert to them PowerMock, JMock or another, if fusesource prefer a different mocking library.

Cheers,

Charles
