### PR TITLE
Group id filter support for maven-graph-plugin

### DIFF
--- a/maven-graph-plugin/src/main/java/org/fusesource/mvnplugins/graph/DependencyVisualizer.java
+++ b/maven-graph-plugin/src/main/java/org/fusesource/mvnplugins/graph/DependencyVisualizer.java
@@ -49,8 +49,8 @@ public class DependencyVisualizer {
     boolean cascade;
     String direction="TB";
     
-    HashSet<String> excludeGroupIds = new HashSet<String>();
-    HashSet<String> includeGroupIds = new HashSet<String>();
+    Set<String> excludeGroupIds = new HashSet<String>();
+    Set<String> includeGroupIds = new HashSet<String>();
     
 
     private class Node {

--- a/maven-graph-plugin/src/main/java/org/fusesource/mvnplugins/graph/DependencyVisualizer.java
+++ b/maven-graph-plugin/src/main/java/org/fusesource/mvnplugins/graph/DependencyVisualizer.java
@@ -217,6 +217,7 @@ public class DependencyVisualizer {
         private boolean optional;
         private DependencyNode dependencyNode;
         private String groupId;
+        private String artifactId;
 
         public Edge(Node parent, Node child, DependencyNode dependencyNode) {
             this.parent = parent;
@@ -225,6 +226,7 @@ public class DependencyVisualizer {
             this.scope = dependencyNode.getArtifact().getScope();
             this.optional = dependencyNode.getArtifact().isOptional();
             this.groupId = dependencyNode.getArtifact().getGroupId();
+            this.artifactId = dependencyNode.getArtifact().getArtifactId();
         }
         public Edge(Edge edge) {
             this.parent = edge.parent;
@@ -266,11 +268,13 @@ public class DependencyVisualizer {
                   //wildcard match
                   String prefix = exclude.substring(0, exclude.length()-2); //remove ".*"
                   if (groupId.startsWith(prefix)) {
+                     log.debug("Excluding (wildcard) " + groupId + ":" + artifactId);
                      return true;
                   }
                } else {
                   //exact match
                   if (groupId.equals(exclude)) {
+                     log.debug("Excluding " + groupId + ":" + artifactId);
                      return true;
                   }
                }
@@ -281,11 +285,13 @@ public class DependencyVisualizer {
                   //wildcard match
                   String prefix = include.substring(0, include.length()-2); //remove ".*"
                   if (groupId.startsWith(prefix)) {
+                     log.debug("Including (wildcard) " + groupId + ":" + artifactId);
                      return false;
                   }
                } else {
                   //exact match
                   if (groupId.equals(include)) {
+                     log.debug("Including " + groupId + ":" + artifactId);
                      return false;
                   }
                }

--- a/maven-graph-plugin/src/main/java/org/fusesource/mvnplugins/graph/ProjectMojo.java
+++ b/maven-graph-plugin/src/main/java/org/fusesource/mvnplugins/graph/ProjectMojo.java
@@ -166,6 +166,23 @@ public class ProjectMojo extends AbstractMojo {
      * @parameter default-value="false" expression="${hide-group-id}"
      */
     protected boolean hideGroupId;
+    
+    /**
+     * A comma separated list of group Ids to include. If this parameter
+     * is specified, any group Id not matching will  be excluded.
+     * A '*' can be appended <b>only</b> at the end to match subgroups<br/>
+     * For example: <code>com.apache,java.net.*</code>
+     * @parameter expression="${include-group-ids}"
+     */
+    protected String includeGroupIds;
+    
+    /**
+     * A comma separated list of group Ids to exclude. A '*' can be appended
+     * <b>only</b> at the end to match subgroups<br/>
+     * For example: <code>com.apache,java.net.*</code>
+     * @parameter expression="${exclude-group-ids}"
+     */
+    protected String excludeGroupIds;
 
     /**
      * If set to true then the module type label will not be drawn.
@@ -229,8 +246,20 @@ public class ProjectMojo extends AbstractMojo {
 
             if (hideScopes != null) {
                 for (String scope : hideScopes.split(",")) {
-                    visualizer.hideScopes.add(scope);
+                    visualizer.hideScopes.add(scope.trim());
                 }
+            }
+            
+            if (excludeGroupIds != null) {
+               for (String groupId : excludeGroupIds.split(",")) {
+                  visualizer.excludeGroupIds.add(groupId.trim());
+               }
+            }
+            
+            if (includeGroupIds != null) {
+               for (String groupId : includeGroupIds.split(",")) {
+                  visualizer.includeGroupIds.add(groupId.trim());
+               }
             }
 
             ArrayList<MavenProject> projects = new ArrayList<MavenProject>();


### PR DESCRIPTION
This patch will allow to either exclude artifacts whose group id matches the exclude argument or will exclude all artifacts that don't match the include argument

The two new arguments are **includeGroupIds** and **excludeGroupIds** and they both support a wildcard at the end to match more than one packge (e.g. com.sun.*)