### PR TITLE
Add Version Major-Minor slot strategy

### DIFF
--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/domain/ModuleBuilder.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/domain/ModuleBuilder.java
@@ -136,7 +136,7 @@ public final class ModuleBuilder
     return slot;
   }
 
-//  private static String calcSlot(final SlotStrategy strategy,
+//  private static String calculateSlot(final SlotStrategy strategy,
 //      final String defaultSlot, final String moduleSlot, final Artifact artifact)
 //  {
 //    final String slot;
@@ -144,7 +144,7 @@ public final class ModuleBuilder
 //    {
 //      if (artifact != null)
 //      {
-//        slot = strategy.calcSlot(artifact, defaultSlot);
+//        slot = strategy.calculateSlot(artifact, defaultSlot);
 //      }
 //      else
 //      {

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/domain/SlotStrategy.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/domain/SlotStrategy.java
@@ -151,10 +151,11 @@ public enum SlotStrategy
   public abstract String calculateSlot(final Artifact artifact, final String defaultSlot);
 
   /**
+   * Apply the slot strategy to the slot given.
    *
-   * @param defaultSlot
-   * @param slot
-   * @return
+   * @param defaultSlot  the default slot touse
+   * @param slot the slot to apply the strategy to
+   * @return the slot with the strategy applied.
    */
   private static String applySlotStrategy(final String defaultSlot, String slot)
   {

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/domain/SlotStrategy.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/domain/SlotStrategy.java
@@ -38,7 +38,7 @@ public enum SlotStrategy
    */
   MAIN("main") {
     @Override
-    String calculateSlot(Artifact artifact, String defaultSlot) {
+    String calculateSlot(final ArtifactVersion version, final String defaultSlot) {
       return StringUtils.isBlank(defaultSlot) ? MAIN_SLOT : defaultSlot;
     }
   },
@@ -48,10 +48,9 @@ public enum SlotStrategy
    */
   VERSION_MAJOR_MINOR("version-major-minor") {
     @Override
-    String calculateSlot(Artifact artifact, String defaultSlot) {
-      final ArtifactVersion version = calcVersion(artifact);
+    String calculateSlot(final ArtifactVersion version, final String defaultSlot) {
       final String slot = String.format("%s.%s", String.valueOf(version.getMajorVersion()),
-                                                 String.valueOf(version.getMinorVersion()));
+          String.valueOf(version.getMinorVersion()));
       return applySlotStrategy(defaultSlot, slot);
     }
   },
@@ -61,8 +60,7 @@ public enum SlotStrategy
    */
   VERSION_MAJOR("version-major") {
     @Override
-    String calculateSlot(Artifact artifact, String defaultSlot) {
-      final ArtifactVersion version = calcVersion(artifact);
+    String calculateSlot(final ArtifactVersion version, final String defaultSlot) {
       return applySlotStrategy(defaultSlot, String.valueOf(version.getMajorVersion()));
     }
   },
@@ -72,8 +70,7 @@ public enum SlotStrategy
    */
   VERSION_FULL("version-full") {
     @Override
-    String calculateSlot(Artifact artifact, String defaultSlot) {
-      final ArtifactVersion version = calcVersion(artifact);
+    String calculateSlot(final ArtifactVersion version, final String defaultSlot) {
       String slot = String.format("%s.%s.%s", String.valueOf(version.getMajorVersion()),
                                               String.valueOf(version.getMinorVersion()),
                                               String.valueOf(version.getIncrementalVersion()));
@@ -143,12 +140,11 @@ public enum SlotStrategy
   /**
    * Calculates the name for the slot, each type of SlotStrategy has a different implementation.
    *
-   * @param artifact the artifact with additional information. If
-   *          <code>null</code>: a static prefix will be assumed.
+   * @param version the {@link org.apache.maven.artifact.versioning.ArtifactVersion}.
    * @param defaultSlot the name of the default slot to use.
    * @return the name of the slot.
    */
-  abstract String calculateSlot(final Artifact artifact, final String defaultSlot);
+  abstract String calculateSlot(final ArtifactVersion version, final String defaultSlot);
 
   /**
    * Apply the slot strategy to the slot given.
@@ -179,7 +175,7 @@ public enum SlotStrategy
       final Artifact artifact)
   {
     final String fallBackSlot = StringUtils.isBlank(moduleSlot) ? defaultSlot : moduleSlot;
-    return calculateSlot(artifact, fallBackSlot);
+    return calculateSlot(calculateVersion(artifact), fallBackSlot);
   }
 
   /**
@@ -190,7 +186,7 @@ public enum SlotStrategy
    * @return the {@link org.apache.maven.artifact.versioning.ArtifactVersion} created from
    *         the version or if the version is null it is set to VersionX.
    */
-  ArtifactVersion calcVersion(final Artifact artifact)
+  ArtifactVersion calculateVersion(final Artifact artifact)
   {
       return new DefaultArtifactVersion(artifact == null ? "VersionX" : artifact.getVersion());
   }

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/domain/SlotStrategy.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/domain/SlotStrategy.java
@@ -38,7 +38,7 @@ public enum SlotStrategy
    */
   MAIN("main") {
     @Override
-    public String calculateSlot(Artifact artifact, String defaultSlot) {
+    String calculateSlot(Artifact artifact, String defaultSlot) {
       return StringUtils.isBlank(defaultSlot) ? MAIN_SLOT : defaultSlot;
     }
   },
@@ -48,7 +48,7 @@ public enum SlotStrategy
    */
   VERSION_MAJOR_MINOR("version-major-minor") {
     @Override
-    public String calculateSlot(Artifact artifact, String defaultSlot) {
+    String calculateSlot(Artifact artifact, String defaultSlot) {
       final ArtifactVersion version = calcVersion(artifact);
       final String slot = String.format("%s.%s", String.valueOf(version.getMajorVersion()),
                                                  String.valueOf(version.getMinorVersion()));
@@ -61,7 +61,7 @@ public enum SlotStrategy
    */
   VERSION_MAJOR("version-major") {
     @Override
-    public String calculateSlot(Artifact artifact, String defaultSlot) {
+    String calculateSlot(Artifact artifact, String defaultSlot) {
       final ArtifactVersion version = calcVersion(artifact);
       return applySlotStrategy(defaultSlot, String.valueOf(version.getMajorVersion()));
     }
@@ -72,7 +72,7 @@ public enum SlotStrategy
    */
   VERSION_FULL("version-full") {
     @Override
-    public String calculateSlot(Artifact artifact, String defaultSlot) {
+    String calculateSlot(Artifact artifact, String defaultSlot) {
       final ArtifactVersion version = calcVersion(artifact);
       String slot = String.format("%s.%s.%s", String.valueOf(version.getMajorVersion()),
                                               String.valueOf(version.getMinorVersion()),
@@ -148,7 +148,7 @@ public enum SlotStrategy
    * @param defaultSlot the name of the default slot to use.
    * @return the name of the slot.
    */
-  public abstract String calculateSlot(final Artifact artifact, final String defaultSlot);
+  abstract String calculateSlot(final Artifact artifact, final String defaultSlot);
 
   /**
    * Apply the slot strategy to the slot given.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/xml/ModuleXmlBuilder.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/xml/ModuleXmlBuilder.java
@@ -388,7 +388,7 @@ public final class ModuleXmlBuilder
     final Dependency dependency = element.dependency;
     final String defaultSlot = calcDefaultSlot(module, dependency);
     final String slot =
-        slotStrategy.calculateSlot(dependency.getArtifact(), defaultSlot);
+        slotStrategy.calcSlot(defaultSlot, StringUtils.EMPTY, dependency.getArtifact());
     if (!SlotStrategy.MAIN_SLOT.equals(slot))
     {
       moduleElement.setAttribute("slot", slot);

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/xml/ModuleXmlBuilder.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/xml/ModuleXmlBuilder.java
@@ -388,7 +388,7 @@ public final class ModuleXmlBuilder
     final Dependency dependency = element.dependency;
     final String defaultSlot = calcDefaultSlot(module, dependency);
     final String slot =
-        slotStrategy.calcSlot(dependency.getArtifact(), defaultSlot);
+        slotStrategy.calculateSlot(dependency.getArtifact(), defaultSlot);
     if (!SlotStrategy.MAIN_SLOT.equals(slot))
     {
       moduleElement.setAttribute("slot", slot);

--- a/smartics-jboss-modules-maven-plugin/src/test/java/de/smartics/maven/plugin/jboss/modules/domain/AbstractSlotStrategyTest.java
+++ b/smartics-jboss-modules-maven-plugin/src/test/java/de/smartics/maven/plugin/jboss/modules/domain/AbstractSlotStrategyTest.java
@@ -1,0 +1,43 @@
+package de.smartics.maven.plugin.jboss.modules.domain;
+
+import org.apache.maven.artifact.versioning.ArtifactVersion;
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+
+/**
+ * A common base class from the {@link de.smartics.maven.plugin.jboss.modules.domain.SlotStrategy} tests.
+ */
+abstract class AbstractSlotStrategyTest {
+  // A simple artifact to use in the tests
+  ArtifactVersion version;
+
+  String expectedVersion;
+
+  // The class under test
+  SlotStrategy slotStrategy;
+
+  /**
+   * Create an {@link org.apache.maven.artifact.versioning.ArtifactVersion}, 
+   * a {@link de.smartics.maven.plugin.jboss.modules.domain.SlotStrategy} and an expected version.
+   *
+   * @param artifactVersion {@link org.apache.maven.artifact.versioning.ArtifactVersion} to use in the tests.
+   * @param slotStrategy {@link de.smartics.maven.plugin.jboss.modules.domain.SlotStrategy} to test.
+   * @param expectedVersion the expected version when testing calculateSlot of SlotStrategy.
+   */
+  AbstractSlotStrategyTest(final String artifactVersion, final SlotStrategy slotStrategy, final String expectedVersion)
+  {
+    this.slotStrategy = slotStrategy;
+    this.expectedVersion = expectedVersion;
+    this.version = new DefaultArtifactVersion(artifactVersion);
+  }
+
+  /**
+   * Test SlotStrategy.calculateSlot(..)
+   */
+  abstract void testVersionForMainDefaultSlotStrategy();
+
+  /**
+   * Test SlotStrategy.fromString()
+   */
+  abstract void testVersionForMainDefaultSlotStrategyFromString();
+
+}

--- a/smartics-jboss-modules-maven-plugin/src/test/java/de/smartics/maven/plugin/jboss/modules/domain/SlotStrategyNonDefaultTest.java
+++ b/smartics-jboss-modules-maven-plugin/src/test/java/de/smartics/maven/plugin/jboss/modules/domain/SlotStrategyNonDefaultTest.java
@@ -1,0 +1,76 @@
+package de.smartics.maven.plugin.jboss.modules.domain;
+
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+/**
+ * Tests {@link de.smartics.maven.plugin.jboss.modules.domain.SlotStrategy} with the non default
+ * ie. non MAIN slot strategy.
+ */
+@RunWith(Parameterized.class)
+public class SlotStrategyNonDefaultTest {
+
+  // A simple artifact to use in the tests
+  private Artifact artifact;
+
+  private String expectedVersion;
+
+  // The class under test
+  private SlotStrategy slotStrategy;
+
+  // The default slot strategy, normally main
+  private String defaultNonMainSlotStrategy;
+
+  @Parameterized.Parameters
+  public static Collection<Object[]> data() {
+    return Arrays.asList(new Object[][]{
+        {"1.2.3", SlotStrategy.VERSION_MAJOR, "non-main", "non-main1"},
+        {"4.5", SlotStrategy.VERSION_MAJOR, "non-default", "non-default4"},
+        {"4.5", SlotStrategy.VERSION_MAJOR_MINOR, "anotherDefault", "anotherDefault4.5"},
+        {"4.5.7", SlotStrategy.VERSION_MAJOR_MINOR, "anotherDefault", "anotherDefault4.5"},
+        {"4", SlotStrategy.VERSION_MAJOR_MINOR, "anotherDefault", "anotherDefault4.5"},
+        {"4.5", SlotStrategy.VERSION_FULL, "semi-osgi-slot", "semi-osgi-slot4.5.0"}
+    });
+  }
+
+  /**
+   * For each test create an artifact and use {@link de.smartics.maven.plugin.jboss.modules.domain.SlotStrategy}
+   * to calculate the version and test it against the expected version.
+   *
+   * @param artifactVersion the version of the {@link org.eclipse.aether.artifact.Artifact} to create.
+   * @param slotStrategy the {@link de.smartics.maven.plugin.jboss.modules.domain.SlotStrategy} to test.
+   * @param defaultNonMainSlotStrategy the default slot strategy non Main
+   * @param expectedVersion the expected version.
+   */
+  public SlotStrategyNonDefaultTest(final String artifactVersion, final SlotStrategy slotStrategy,
+                                    final String defaultNonMainSlotStrategy, final String expectedVersion) {
+    this.slotStrategy = slotStrategy;
+    this.expectedVersion = expectedVersion;
+    this.defaultNonMainSlotStrategy = defaultNonMainSlotStrategy;
+
+    this.artifact = new DefaultArtifact("com.yourcompany", "awesome-artifact", "jar", artifactVersion);
+  }
+
+  @Test
+  public void testVersionForNonMainDefaultSlotStrategy() {
+    assertNotEquals("default non main slot strategy incorrect", SlotStrategy.MAIN_SLOT, defaultNonMainSlotStrategy);
+    assertEquals("strategy version incorrect", expectedVersion,
+        slotStrategy.calculateSlot(artifact, defaultNonMainSlotStrategy));
+  }
+
+  @Test
+  public void testVersionForNonMainDefaultSlotStrategyfromStrategy() {
+    assertEquals("strategy version incorrect", expectedVersion,
+        SlotStrategy.fromString(slotStrategy.toString()).calculateSlot(artifact, defaultNonMainSlotStrategy));
+  }
+
+}

--- a/smartics-jboss-modules-maven-plugin/src/test/java/de/smartics/maven/plugin/jboss/modules/domain/SlotStrategyNonDefaultTest.java
+++ b/smartics-jboss-modules-maven-plugin/src/test/java/de/smartics/maven/plugin/jboss/modules/domain/SlotStrategyNonDefaultTest.java
@@ -1,7 +1,5 @@
 package de.smartics.maven.plugin.jboss.modules.domain;
 
-import org.eclipse.aether.artifact.Artifact;
-import org.eclipse.aether.artifact.DefaultArtifact;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -17,15 +15,7 @@ import static org.junit.Assert.assertNotEquals;
  * ie. non MAIN slot strategy.
  */
 @RunWith(Parameterized.class)
-public class SlotStrategyNonDefaultTest {
-
-  // A simple artifact to use in the tests
-  private Artifact artifact;
-
-  private String expectedVersion;
-
-  // The class under test
-  private SlotStrategy slotStrategy;
+public class SlotStrategyNonDefaultTest extends AbstractSlotStrategyTest {
 
   // The default slot strategy, normally main
   private String defaultNonMainSlotStrategy;
@@ -53,24 +43,21 @@ public class SlotStrategyNonDefaultTest {
    */
   public SlotStrategyNonDefaultTest(final String artifactVersion, final SlotStrategy slotStrategy,
                                     final String defaultNonMainSlotStrategy, final String expectedVersion) {
-    this.slotStrategy = slotStrategy;
-    this.expectedVersion = expectedVersion;
+    super(artifactVersion, slotStrategy, expectedVersion);
     this.defaultNonMainSlotStrategy = defaultNonMainSlotStrategy;
-
-    this.artifact = new DefaultArtifact("com.yourcompany", "awesome-artifact", "jar", artifactVersion);
   }
 
   @Test
-  public void testVersionForNonMainDefaultSlotStrategy() {
+  public void testVersionForMainDefaultSlotStrategy() {
     assertNotEquals("default non main slot strategy incorrect", SlotStrategy.MAIN_SLOT, defaultNonMainSlotStrategy);
-    assertEquals("strategy version incorrect", expectedVersion,
-        slotStrategy.calculateSlot(artifact, defaultNonMainSlotStrategy));
+    assertEquals("strategy version for non default slot incorrect", expectedVersion,
+        slotStrategy.calculateSlot(version, defaultNonMainSlotStrategy));
   }
 
   @Test
-  public void testVersionForNonMainDefaultSlotStrategyfromStrategy() {
-    assertEquals("strategy version incorrect", expectedVersion,
-        SlotStrategy.fromString(slotStrategy.toString()).calculateSlot(artifact, defaultNonMainSlotStrategy));
+  public void testVersionForMainDefaultSlotStrategyFromString() {
+    assertEquals("strategy version for non default slot incorrect", expectedVersion,
+        SlotStrategy.fromString(slotStrategy.toString()).calculateSlot(version, defaultNonMainSlotStrategy));
   }
 
 }

--- a/smartics-jboss-modules-maven-plugin/src/test/java/de/smartics/maven/plugin/jboss/modules/domain/SlotStrategyNonDefaultTest.java
+++ b/smartics-jboss-modules-maven-plugin/src/test/java/de/smartics/maven/plugin/jboss/modules/domain/SlotStrategyNonDefaultTest.java
@@ -37,7 +37,7 @@ public class SlotStrategyNonDefaultTest {
         {"4.5", SlotStrategy.VERSION_MAJOR, "non-default", "non-default4"},
         {"4.5", SlotStrategy.VERSION_MAJOR_MINOR, "anotherDefault", "anotherDefault4.5"},
         {"4.5.7", SlotStrategy.VERSION_MAJOR_MINOR, "anotherDefault", "anotherDefault4.5"},
-        {"4", SlotStrategy.VERSION_MAJOR_MINOR, "anotherDefault", "anotherDefault4.5"},
+        {"4", SlotStrategy.VERSION_MAJOR_MINOR, "anotherDefault", "anotherDefault4.0"},
         {"4.5", SlotStrategy.VERSION_FULL, "semi-osgi-slot", "semi-osgi-slot4.5.0"}
     });
   }

--- a/smartics-jboss-modules-maven-plugin/src/test/java/de/smartics/maven/plugin/jboss/modules/domain/SlotStrategyTest.java
+++ b/smartics-jboss-modules-maven-plugin/src/test/java/de/smartics/maven/plugin/jboss/modules/domain/SlotStrategyTest.java
@@ -1,0 +1,51 @@
+package de.smartics.maven.plugin.jboss.modules.domain;
+
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests {@link de.smartics.maven.plugin.jboss.modules.domain.SlotStrategy}.
+ */
+@RunWith(Parameterized.class)
+public class SlotStrategyTest {
+
+    private Artifact artifact = new DefaultArtifact("com.yourcompany", "awesome-artifact", "jar", "1.2.3");
+
+    private SlotStrategy slotStrategy;
+
+    private String expectedVersion;
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {"1.2.3", SlotStrategy.MAIN, "main"},
+                {"1.2.3", SlotStrategy.VERSION_MAJOR, "1"},
+                {"4.5", SlotStrategy.VERSION_MAJOR, "4"},
+                {"4.5", SlotStrategy.VERSION_MAJOR, "4"},
+                {"4.5", SlotStrategy.VERSION_FULL, "4.5.0"},
+                {"4.5", SlotStrategy.MAIN, "main"}
+        });
+    }
+
+    public SlotStrategyTest(String artifactVersion, SlotStrategy slotStrategy, String expectedVersion) {
+        this.slotStrategy = slotStrategy;
+        this.expectedVersion = expectedVersion;
+
+        this.artifact = new DefaultArtifact("com.yourcompany", "awesome-artifact", "jar", artifactVersion);
+    }
+
+    @Test
+    public void testVersionForSlotStrategy() {
+        assertEquals("strategy version incorrect", expectedVersion,
+                slotStrategy.calcSlot(artifact, SlotStrategy.MAIN_SLOT));
+    }
+
+}

--- a/smartics-jboss-modules-maven-plugin/src/test/java/de/smartics/maven/plugin/jboss/modules/domain/SlotStrategyTest.java
+++ b/smartics-jboss-modules-maven-plugin/src/test/java/de/smartics/maven/plugin/jboss/modules/domain/SlotStrategyTest.java
@@ -12,16 +12,18 @@ import java.util.Collection;
 import static org.junit.Assert.assertEquals;
 
 /**
- * Tests {@link de.smartics.maven.plugin.jboss.modules.domain.SlotStrategy}.
+ * Tests {@link de.smartics.maven.plugin.jboss.modules.domain.SlotStrategy} with the default MAIN slot strategy.
  */
 @RunWith(Parameterized.class)
 public class SlotStrategyTest {
 
-    private Artifact artifact = new DefaultArtifact("com.yourcompany", "awesome-artifact", "jar", "1.2.3");
-
-    private SlotStrategy slotStrategy;
+    // A simple artifact to use in the tests
+    private Artifact artifact;
 
     private String expectedVersion;
+
+    // The class under test
+    private SlotStrategy slotStrategy;
 
     @Parameterized.Parameters
     public static Collection<Object[]> data() {
@@ -29,13 +31,24 @@ public class SlotStrategyTest {
                 {"1.2.3", SlotStrategy.MAIN, "main"},
                 {"1.2.3", SlotStrategy.VERSION_MAJOR, "1"},
                 {"4.5", SlotStrategy.VERSION_MAJOR, "4"},
-                {"4.5", SlotStrategy.VERSION_MAJOR, "4"},
+                {"4.5", SlotStrategy.VERSION_MAJOR_MINOR, "4.5"},
+                {"4.5.3", SlotStrategy.VERSION_MAJOR_MINOR, "4.5"},
+                {"4", SlotStrategy.VERSION_MAJOR_MINOR, "4.0"},
                 {"4.5", SlotStrategy.VERSION_FULL, "4.5.0"},
                 {"4.5", SlotStrategy.MAIN, "main"}
         });
     }
 
-    public SlotStrategyTest(String artifactVersion, SlotStrategy slotStrategy, String expectedVersion) {
+    /**
+     * For each test create an artifact and use {@link de.smartics.maven.plugin.jboss.modules.domain.SlotStrategy}
+     * to calculate the version and test it against the expected version.
+     *
+     * @param artifactVersion the version of the {@link org.eclipse.aether.artifact.Artifact} to create.
+     * @param slotStrategy the {@link de.smartics.maven.plugin.jboss.modules.domain.SlotStrategy} to test.
+     * @param expectedVersion the expected version.
+     */
+    public SlotStrategyTest(final String artifactVersion, final SlotStrategy slotStrategy,
+                            final String expectedVersion) {
         this.slotStrategy = slotStrategy;
         this.expectedVersion = expectedVersion;
 
@@ -43,9 +56,15 @@ public class SlotStrategyTest {
     }
 
     @Test
-    public void testVersionForSlotStrategy() {
+    public void testVersionForMainDefaultSlotStrategy() {
         assertEquals("strategy version incorrect", expectedVersion,
-                slotStrategy.calcSlot(artifact, SlotStrategy.MAIN_SLOT));
+                slotStrategy.calculateSlot(artifact, SlotStrategy.MAIN_SLOT));
+    }
+
+    @Test
+    public void testVersionForMainDefaultSlotStrategyfromStrategy() {
+        assertEquals("strategy version incorrect", expectedVersion,
+                SlotStrategy.fromString(slotStrategy.toString()).calculateSlot(artifact, SlotStrategy.MAIN_SLOT));
     }
 
 }

--- a/smartics-jboss-modules-maven-plugin/src/test/java/de/smartics/maven/plugin/jboss/modules/domain/SlotStrategyTest.java
+++ b/smartics-jboss-modules-maven-plugin/src/test/java/de/smartics/maven/plugin/jboss/modules/domain/SlotStrategyTest.java
@@ -1,7 +1,5 @@
 package de.smartics.maven.plugin.jboss.modules.domain;
 
-import org.eclipse.aether.artifact.Artifact;
-import org.eclipse.aether.artifact.DefaultArtifact;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -15,16 +13,8 @@ import static org.junit.Assert.assertEquals;
  * Tests {@link de.smartics.maven.plugin.jboss.modules.domain.SlotStrategy} with the default MAIN slot strategy.
  */
 @RunWith(Parameterized.class)
-public class SlotStrategyTest {
-
-    // A simple artifact to use in the tests
-    private Artifact artifact;
-
-    private String expectedVersion;
-
-    // The class under test
-    private SlotStrategy slotStrategy;
-
+public class SlotStrategyTest extends AbstractSlotStrategyTest {
+  
     @Parameterized.Parameters
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][]{
@@ -49,22 +39,19 @@ public class SlotStrategyTest {
      */
     public SlotStrategyTest(final String artifactVersion, final SlotStrategy slotStrategy,
                             final String expectedVersion) {
-        this.slotStrategy = slotStrategy;
-        this.expectedVersion = expectedVersion;
-
-        this.artifact = new DefaultArtifact("com.yourcompany", "awesome-artifact", "jar", artifactVersion);
+      super(artifactVersion, slotStrategy, expectedVersion);
     }
 
     @Test
     public void testVersionForMainDefaultSlotStrategy() {
         assertEquals("strategy version incorrect", expectedVersion,
-                slotStrategy.calculateSlot(artifact, SlotStrategy.MAIN_SLOT));
+                slotStrategy.calculateSlot(version, SlotStrategy.MAIN_SLOT));
     }
 
     @Test
-    public void testVersionForMainDefaultSlotStrategyfromStrategy() {
+    public void testVersionForMainDefaultSlotStrategyFromString() {
         assertEquals("strategy version incorrect", expectedVersion,
-                SlotStrategy.fromString(slotStrategy.toString()).calculateSlot(artifact, SlotStrategy.MAIN_SLOT));
+                SlotStrategy.fromString(slotStrategy.toString()).calculateSlot(version, SlotStrategy.MAIN_SLOT));
     }
 
 }


### PR DESCRIPTION
Extend the SlotStrategy class to provide a Major-Minor version number. This is useful since EARs and WARs can depend on a Major-Minor version of a module and if there are bug fix releases to the module the EARs and WARs do not need rebuilding.