### PR TITLE
Upgrade smartics plugin to work with maven 3.2.5 and above

### DIFF
--- a/smartics-jboss-modules-maven-plugin/COPYRIGHT.txt
+++ b/smartics-jboss-modules-maven-plugin/COPYRIGHT.txt
@@ -1,4 +1,4 @@
-Copyright 2013 smartics, Kronseder &amp; Reiner GmbH
+Copyright 2013-2015 smartics, Kronseder &amp; Reiner GmbH
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/pom.xml
+++ b/smartics-jboss-modules-maven-plugin/pom.xml
@@ -47,10 +47,10 @@
     <ohlohProjectId>710977</ohlohProjectId>
     <twitterId>smartics</twitterId>
 
-    <maven.version>3.1.0</maven.version>
+    <maven.version>3.2.5</maven.version>
     <maven.project.version>2.2.1</maven.project.version>
     <maven-plugin-plugin.version>3.2</maven-plugin-plugin.version>
-    <aether.version>0.9.0.M2</aether.version>
+    <aether.version>1.0.0.v20140518</aether.version>
 
     <smartics-commons.version>0.5.2</smartics-commons.version>
     <testdoc.version>0.4.1</testdoc.version>
@@ -121,12 +121,7 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-connector-wagon</artifactId>
-      <version>${aether.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-connector-file</artifactId>
+      <artifactId>aether-transport-wagon</artifactId>
       <version>${aether.version}</version>
     </dependency>
     <dependency>

--- a/smartics-jboss-modules-maven-plugin/src/etc/xsl/create-modules-doc.xsl
+++ b/smartics-jboss-modules-maven-plugin/src/etc/xsl/create-modules-doc.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+    Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/add-dependencies-merge/invoker.properties
+++ b/smartics-jboss-modules-maven-plugin/src/it/add-dependencies-merge/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+# Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/add-dependencies-merge/src/etc/jboss-modules/modules.xml
+++ b/smartics-jboss-modules-maven-plugin/src/it/add-dependencies-merge/src/etc/jboss-modules/modules.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+    Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/add-dependencies-merge/validate.groovy
+++ b/smartics-jboss-modules-maven-plugin/src/it/add-dependencies-merge/validate.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/add-dependencies/invoker.properties
+++ b/smartics-jboss-modules-maven-plugin/src/it/add-dependencies/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+# Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/add-dependencies/src/etc/jboss-modules/modules.xml
+++ b/smartics-jboss-modules-maven-plugin/src/it/add-dependencies/src/etc/jboss-modules/modules.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+    Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/add-dependencies/validate.groovy
+++ b/smartics-jboss-modules-maven-plugin/src/it/add-dependencies/validate.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/add-dependency/invoker.properties
+++ b/smartics-jboss-modules-maven-plugin/src/it/add-dependency/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+# Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/add-dependency/src/etc/jboss-modules/modules.xml
+++ b/smartics-jboss-modules-maven-plugin/src/it/add-dependency/src/etc/jboss-modules/modules.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+    Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/add-dependency/validate.groovy
+++ b/smartics-jboss-modules-maven-plugin/src/it/add-dependency/validate.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/apply-dependency-excludes/invoker.properties
+++ b/smartics-jboss-modules-maven-plugin/src/it/apply-dependency-excludes/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+# Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/apply-dependency-excludes/src/etc/jboss-modules/modules.xml
+++ b/smartics-jboss-modules-maven-plugin/src/it/apply-dependency-excludes/src/etc/jboss-modules/modules.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+    Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/apply-dependency-excludes/validate.groovy
+++ b/smartics-jboss-modules-maven-plugin/src/it/apply-dependency-excludes/validate.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/bom-bom/invoker.properties
+++ b/smartics-jboss-modules-maven-plugin/src/it/bom-bom/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+# Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/bom-bom/src/etc/jboss-modules/modules.xml
+++ b/smartics-jboss-modules-maven-plugin/src/it/bom-bom/src/etc/jboss-modules/modules.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+    Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/bom-bom/validate.groovy
+++ b/smartics-jboss-modules-maven-plugin/src/it/bom-bom/validate.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/changing-coordinates/invoker.properties
+++ b/smartics-jboss-modules-maven-plugin/src/it/changing-coordinates/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+# Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/changing-coordinates/src/etc/jboss-modules/modules.xml
+++ b/smartics-jboss-modules-maven-plugin/src/it/changing-coordinates/src/etc/jboss-modules/modules.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+    Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/changing-coordinates/validate.groovy
+++ b/smartics-jboss-modules-maven-plugin/src/it/changing-coordinates/validate.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/exclude-transitive/invoker.properties
+++ b/smartics-jboss-modules-maven-plugin/src/it/exclude-transitive/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+# Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/exclude-transitive/validate.groovy
+++ b/smartics-jboss-modules-maven-plugin/src/it/exclude-transitive/validate.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/excludes/invoker.properties
+++ b/smartics-jboss-modules-maven-plugin/src/it/excludes/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+# Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/excludes/src/etc/jboss-modules/modules.xml
+++ b/smartics-jboss-modules-maven-plugin/src/it/excludes/src/etc/jboss-modules/modules.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+    Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/excludes/validate.groovy
+++ b/smartics-jboss-modules-maven-plugin/src/it/excludes/validate.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/export-all/invoker.properties
+++ b/smartics-jboss-modules-maven-plugin/src/it/export-all/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+# Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/export-all/src/etc/jboss-modules/modules.xml
+++ b/smartics-jboss-modules-maven-plugin/src/it/export-all/src/etc/jboss-modules/modules.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+    Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/export-all/validate.groovy
+++ b/smartics-jboss-modules-maven-plugin/src/it/export-all/validate.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/export-none/invoker.properties
+++ b/smartics-jboss-modules-maven-plugin/src/it/export-none/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+# Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/export-none/src/etc/jboss-modules/modules.xml
+++ b/smartics-jboss-modules-maven-plugin/src/it/export-none/src/etc/jboss-modules/modules.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+    Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/export-none/validate.groovy
+++ b/smartics-jboss-modules-maven-plugin/src/it/export-none/validate.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/export-one-not/invoker.properties
+++ b/smartics-jboss-modules-maven-plugin/src/it/export-one-not/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+# Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/export-one-not/src/etc/jboss-modules/modules.xml
+++ b/smartics-jboss-modules-maven-plugin/src/it/export-one-not/src/etc/jboss-modules/modules.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+    Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/export-one-not/validate.groovy
+++ b/smartics-jboss-modules-maven-plugin/src/it/export-one-not/validate.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/export-some-not/invoker.properties
+++ b/smartics-jboss-modules-maven-plugin/src/it/export-some-not/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+# Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/export-some-not/src/etc/jboss-modules/modules.xml
+++ b/smartics-jboss-modules-maven-plugin/src/it/export-some-not/src/etc/jboss-modules/modules.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+    Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/export-some-not/validate.groovy
+++ b/smartics-jboss-modules-maven-plugin/src/it/export-some-not/validate.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/export-some-restricted/invoker.properties
+++ b/smartics-jboss-modules-maven-plugin/src/it/export-some-restricted/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+# Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/export-some-restricted/src/etc/jboss-modules/modules.xml
+++ b/smartics-jboss-modules-maven-plugin/src/it/export-some-restricted/src/etc/jboss-modules/modules.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+    Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/export-some-restricted/validate.groovy
+++ b/smartics-jboss-modules-maven-plugin/src/it/export-some-restricted/validate.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/export-some/invoker.properties
+++ b/smartics-jboss-modules-maven-plugin/src/it/export-some/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+# Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/export-some/src/etc/jboss-modules/modules.xml
+++ b/smartics-jboss-modules-maven-plugin/src/it/export-some/src/etc/jboss-modules/modules.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+    Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/export-some/validate.groovy
+++ b/smartics-jboss-modules-maven-plugin/src/it/export-some/validate.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/extension/invoker.properties
+++ b/smartics-jboss-modules-maven-plugin/src/it/extension/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+# Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/extension/src/etc/jboss-modules/modules.xml
+++ b/smartics-jboss-modules-maven-plugin/src/it/extension/src/etc/jboss-modules/modules.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+    Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/extension/validate.groovy
+++ b/smartics-jboss-modules-maven-plugin/src/it/extension/validate.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/import-descriptors-with-target/invoker.properties
+++ b/smartics-jboss-modules-maven-plugin/src/it/import-descriptors-with-target/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+# Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/import-descriptors-with-target/validate.groovy
+++ b/smartics-jboss-modules-maven-plugin/src/it/import-descriptors-with-target/validate.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/import-descriptors/invoker.properties
+++ b/smartics-jboss-modules-maven-plugin/src/it/import-descriptors/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+# Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/import-descriptors/validate.groovy
+++ b/smartics-jboss-modules-maven-plugin/src/it/import-descriptors/validate.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/jar-project/invoker.properties
+++ b/smartics-jboss-modules-maven-plugin/src/it/jar-project/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+# Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/jar-project/src/etc/jboss-modules/modules.xml
+++ b/smartics-jboss-modules-maven-plugin/src/it/jar-project/src/etc/jboss-modules/modules.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+    Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/jar-project/validate.groovy
+++ b/smartics-jboss-modules-maven-plugin/src/it/jar-project/validate.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/maven-excludes-replace/invoker.properties
+++ b/smartics-jboss-modules-maven-plugin/src/it/maven-excludes-replace/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+# Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/maven-excludes-replace/validate.groovy
+++ b/smartics-jboss-modules-maven-plugin/src/it/maven-excludes-replace/validate.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/maven-excludes-skip-replace/invoker.properties
+++ b/smartics-jboss-modules-maven-plugin/src/it/maven-excludes-skip-replace/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+# Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/maven-excludes-skip-replace/validate.groovy
+++ b/smartics-jboss-modules-maven-plugin/src/it/maven-excludes-skip-replace/validate.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/maven-excludes-skip-transitive/invoker.properties
+++ b/smartics-jboss-modules-maven-plugin/src/it/maven-excludes-skip-transitive/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+# Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/maven-excludes-skip-transitive/validate.groovy
+++ b/smartics-jboss-modules-maven-plugin/src/it/maven-excludes-skip-transitive/validate.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/maven-excludes-skip/invoker.properties
+++ b/smartics-jboss-modules-maven-plugin/src/it/maven-excludes-skip/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+# Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/maven-excludes-skip/validate.groovy
+++ b/smartics-jboss-modules-maven-plugin/src/it/maven-excludes-skip/validate.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/maven-excludes-transitive/invoker.properties
+++ b/smartics-jboss-modules-maven-plugin/src/it/maven-excludes-transitive/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+# Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/maven-excludes-transitive/validate.groovy
+++ b/smartics-jboss-modules-maven-plugin/src/it/maven-excludes-transitive/validate.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/maven-excludes/invoker.properties
+++ b/smartics-jboss-modules-maven-plugin/src/it/maven-excludes/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+# Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/maven-excludes/validate.groovy
+++ b/smartics-jboss-modules-maven-plugin/src/it/maven-excludes/validate.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/multimodule-project/invoker.properties
+++ b/smartics-jboss-modules-maven-plugin/src/it/multimodule-project/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+# Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/multimodule-project/src/etc/jboss-modules/modules.xml
+++ b/smartics-jboss-modules-maven-plugin/src/it/multimodule-project/src/etc/jboss-modules/modules.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+    Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/multimodule-project/validate.groovy
+++ b/smartics-jboss-modules-maven-plugin/src/it/multimodule-project/validate.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/no-module-declaration-jar/invoker.properties
+++ b/smartics-jboss-modules-maven-plugin/src/it/no-module-declaration-jar/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+# Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/no-module-declaration-jar/validate.groovy
+++ b/smartics-jboss-modules-maven-plugin/src/it/no-module-declaration-jar/validate.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/no-module-declaration-pom/invoker.properties
+++ b/smartics-jboss-modules-maven-plugin/src/it/no-module-declaration-pom/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+# Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/no-module-declaration-pom/validate.groovy
+++ b/smartics-jboss-modules-maven-plugin/src/it/no-module-declaration-pom/validate.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/non-transitive-dependencies-1/invoker.properties
+++ b/smartics-jboss-modules-maven-plugin/src/it/non-transitive-dependencies-1/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+# Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/non-transitive-dependencies-1/src/etc/jboss-modules/modules.xml
+++ b/smartics-jboss-modules-maven-plugin/src/it/non-transitive-dependencies-1/src/etc/jboss-modules/modules.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+    Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/non-transitive-dependencies-1/validate.groovy
+++ b/smartics-jboss-modules-maven-plugin/src/it/non-transitive-dependencies-1/validate.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/non-transitive-dependencies-2/invoker.properties
+++ b/smartics-jboss-modules-maven-plugin/src/it/non-transitive-dependencies-2/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+# Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/non-transitive-dependencies-2/src/etc/jboss-modules/modules.xml
+++ b/smartics-jboss-modules-maven-plugin/src/it/non-transitive-dependencies-2/src/etc/jboss-modules/modules.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+    Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/non-transitive-dependencies-2/validate.groovy
+++ b/smartics-jboss-modules-maven-plugin/src/it/non-transitive-dependencies-2/validate.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/override-slot/invoker.properties
+++ b/smartics-jboss-modules-maven-plugin/src/it/override-slot/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+# Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/override-slot/src/etc/jboss-modules/modules.xml
+++ b/smartics-jboss-modules-maven-plugin/src/it/override-slot/src/etc/jboss-modules/modules.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+    Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/override-slot/validate.groovy
+++ b/smartics-jboss-modules-maven-plugin/src/it/override-slot/validate.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/redirect-toplevel-dependency-bom/invoker.properties
+++ b/smartics-jboss-modules-maven-plugin/src/it/redirect-toplevel-dependency-bom/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+# Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/redirect-toplevel-dependency-bom/src/etc/jboss-modules/modules.xml
+++ b/smartics-jboss-modules-maven-plugin/src/it/redirect-toplevel-dependency-bom/src/etc/jboss-modules/modules.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+    Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/redirect-toplevel-dependency-bom/validate.groovy
+++ b/smartics-jboss-modules-maven-plugin/src/it/redirect-toplevel-dependency-bom/validate.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/redirect-toplevel-dependency-extension/invoker.properties
+++ b/smartics-jboss-modules-maven-plugin/src/it/redirect-toplevel-dependency-extension/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+# Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/redirect-toplevel-dependency-extension/src/etc/jboss-modules/modules.xml
+++ b/smartics-jboss-modules-maven-plugin/src/it/redirect-toplevel-dependency-extension/src/etc/jboss-modules/modules.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+    Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/redirect-toplevel-dependency-extension/src/main/resources/resource.txt
+++ b/smartics-jboss-modules-maven-plugin/src/it/redirect-toplevel-dependency-extension/src/main/resources/resource.txt
@@ -1,5 +1,5 @@
 ====
-    Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+    Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/redirect-toplevel-dependency-extension/validate.groovy
+++ b/smartics-jboss-modules-maven-plugin/src/it/redirect-toplevel-dependency-extension/validate.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/report-dependency-resolvement-error/invoker.properties
+++ b/smartics-jboss-modules-maven-plugin/src/it/report-dependency-resolvement-error/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+# Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/report-dependency-transitive-resolvement-error/invoker.properties
+++ b/smartics-jboss-modules-maven-plugin/src/it/report-dependency-transitive-resolvement-error/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+# Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/services/invoker.properties
+++ b/smartics-jboss-modules-maven-plugin/src/it/services/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+# Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/services/src/etc/jboss-modules/modules.xml
+++ b/smartics-jboss-modules-maven-plugin/src/it/services/src/etc/jboss-modules/modules.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+    Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/services/validate.groovy
+++ b/smartics-jboss-modules-maven-plugin/src/it/services/validate.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/settings.xml
+++ b/smartics-jboss-modules-maven-plugin/src/it/settings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+    Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/skip-transitive/invoker.properties
+++ b/smartics-jboss-modules-maven-plugin/src/it/skip-transitive/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+# Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/skip-transitive/src/etc/jboss-modules/modules.xml
+++ b/smartics-jboss-modules-maven-plugin/src/it/skip-transitive/src/etc/jboss-modules/modules.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+    Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/skip-transitive/validate.groovy
+++ b/smartics-jboss-modules-maven-plugin/src/it/skip-transitive/validate.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/skip/invoker.properties
+++ b/smartics-jboss-modules-maven-plugin/src/it/skip/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+# Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/skip/src/etc/jboss-modules/modules.xml
+++ b/smartics-jboss-modules-maven-plugin/src/it/skip/src/etc/jboss-modules/modules.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+    Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/skip/validate.groovy
+++ b/smartics-jboss-modules-maven-plugin/src/it/skip/validate.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/slot-inheritance/invoker.properties
+++ b/smartics-jboss-modules-maven-plugin/src/it/slot-inheritance/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+# Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/slot-inheritance/src/etc/jboss-modules/modules.xml
+++ b/smartics-jboss-modules-maven-plugin/src/it/slot-inheritance/src/etc/jboss-modules/modules.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+    Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/slot-inheritance/validate.groovy
+++ b/smartics-jboss-modules-maven-plugin/src/it/slot-inheritance/validate.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/slots-main-non-default/invoker.properties
+++ b/smartics-jboss-modules-maven-plugin/src/it/slots-main-non-default/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+# Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/slots-main-non-default/src/etc/jboss-modules/modules.xml
+++ b/smartics-jboss-modules-maven-plugin/src/it/slots-main-non-default/src/etc/jboss-modules/modules.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+    Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/slots-main-non-default/validate.groovy
+++ b/smartics-jboss-modules-maven-plugin/src/it/slots-main-non-default/validate.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/slots-major-version-prefix/invoker.properties
+++ b/smartics-jboss-modules-maven-plugin/src/it/slots-major-version-prefix/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+# Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/slots-major-version-prefix/src/etc/jboss-modules/modules.xml
+++ b/smartics-jboss-modules-maven-plugin/src/it/slots-major-version-prefix/src/etc/jboss-modules/modules.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+    Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/slots-major-version-prefix/validate.groovy
+++ b/smartics-jboss-modules-maven-plugin/src/it/slots-major-version-prefix/validate.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/slots-major-version-pure/invoker.properties
+++ b/smartics-jboss-modules-maven-plugin/src/it/slots-major-version-pure/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+# Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/slots-major-version-pure/src/etc/jboss-modules/modules.xml
+++ b/smartics-jboss-modules-maven-plugin/src/it/slots-major-version-pure/src/etc/jboss-modules/modules.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+    Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/slots-major-version-pure/validate.groovy
+++ b/smartics-jboss-modules-maven-plugin/src/it/slots-major-version-pure/validate.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/top-main/invoker.properties
+++ b/smartics-jboss-modules-maven-plugin/src/it/top-main/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+# Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/top-main/src/etc/jboss-modules/modules.xml
+++ b/smartics-jboss-modules-maven-plugin/src/it/top-main/src/etc/jboss-modules/modules.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+    Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/top-main/validate.groovy
+++ b/smartics-jboss-modules-maven-plugin/src/it/top-main/validate.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/transitive-dependencies-1/invoker.properties
+++ b/smartics-jboss-modules-maven-plugin/src/it/transitive-dependencies-1/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+# Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/transitive-dependencies-1/src/etc/jboss-modules/modules.xml
+++ b/smartics-jboss-modules-maven-plugin/src/it/transitive-dependencies-1/src/etc/jboss-modules/modules.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+    Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/transitive-dependencies-1/validate.groovy
+++ b/smartics-jboss-modules-maven-plugin/src/it/transitive-dependencies-1/validate.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/transitive-dependencies-2/invoker.properties
+++ b/smartics-jboss-modules-maven-plugin/src/it/transitive-dependencies-2/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+# Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/transitive-dependencies-2/src/etc/jboss-modules/modules.xml
+++ b/smartics-jboss-modules-maven-plugin/src/it/transitive-dependencies-2/src/etc/jboss-modules/modules.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+    Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/transitive-dependencies-2/validate.groovy
+++ b/smartics-jboss-modules-maven-plugin/src/it/transitive-dependencies-2/validate.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/transitive-optional-dependencies/invoker.properties
+++ b/smartics-jboss-modules-maven-plugin/src/it/transitive-optional-dependencies/invoker.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+# Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/transitive-optional-dependencies/src/etc/jboss-modules/modules.xml
+++ b/smartics-jboss-modules-maven-plugin/src/it/transitive-optional-dependencies/src/etc/jboss-modules/modules.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+    Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/it/transitive-optional-dependencies/validate.groovy
+++ b/smartics-jboss-modules-maven-plugin/src/it/transitive-optional-dependencies/validate.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/FileSet.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/FileSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/IndexMojo.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/IndexMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/JBossModulesArchiveMojo.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/JBossModulesArchiveMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/JandexMojo.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/JandexMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/aether/DelegateDependencyTraverser.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/aether/DelegateDependencyTraverser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/aether/DependencyTraverserGenerator.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/aether/DependencyTraverserGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/aether/FilterSession.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/aether/FilterSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/aether/Mapper.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/aether/Mapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/aether/MavenRepository.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/aether/MavenRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/aether/MavenResponse.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/aether/MavenResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/aether/MojoRepositoryBuilder.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/aether/MojoRepositoryBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/aether/PruningDependencyTraverser.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/aether/PruningDependencyTraverser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/aether/RepositoryBuilder.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/aether/RepositoryBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/aether/RepositoryLogListener.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/aether/RepositoryLogListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/aether/RepositoryWagonProvider.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/aether/RepositoryWagonProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package de.smartics.maven.plugin.jboss.modules.aether;
 import org.apache.maven.wagon.Wagon;
 import org.apache.maven.wagon.providers.http.LightweightHttpWagon;
 import org.apache.maven.wagon.providers.http.LightweightHttpsWagon;
-import org.eclipse.aether.connector.wagon.WagonProvider;
+import org.eclipse.aether.transport.wagon.WagonProvider;
 
 /**
  * Mapper to support HTTP and HTTPS protocols.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/aether/filter/DefaultTransitiveDependencyResolver.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/aether/filter/DefaultTransitiveDependencyResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/aether/filter/DependencyFlagger.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/aether/filter/DependencyFlagger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/aether/filter/DirectDependenciesOnlyFilter.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/aether/filter/DirectDependenciesOnlyFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/aether/filter/ExclusionFilter.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/aether/filter/ExclusionFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/aether/filter/GaExclusionFilter.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/aether/filter/GaExclusionFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/aether/filter/TestScopeFilter.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/aether/filter/TestScopeFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/aether/filter/package-info.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/aether/filter/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/aether/package-info.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/aether/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/descriptor/ApplyToDependencies.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/descriptor/ApplyToDependencies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/descriptor/ApplyToModule.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/descriptor/ApplyToModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/descriptor/ArtifactClusion.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/descriptor/ArtifactClusion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/descriptor/ArtifactMatcher.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/descriptor/ArtifactMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/descriptor/DependenciesDescriptor.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/descriptor/DependenciesDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/descriptor/Directives.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/descriptor/Directives.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/descriptor/ModuleClusion.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/descriptor/ModuleClusion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/descriptor/ModuleDescriptor.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/descriptor/ModuleDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/descriptor/ModuleMatcher.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/descriptor/ModuleMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/descriptor/ModulesDescriptor.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/descriptor/ModulesDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/descriptor/package-info.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/descriptor/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/domain/ExecutionContext.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/domain/ExecutionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/domain/MatchContext.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/domain/MatchContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/domain/ModuleBuilder.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/domain/ModuleBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/domain/ModuleMap.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/domain/ModuleMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/domain/PrunerGenerator.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/domain/PrunerGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/domain/SlotStrategy.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/domain/SlotStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/domain/TransitiveDependencyResolver.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/domain/TransitiveDependencyResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/domain/matching/DelegationMatchContext.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/domain/matching/DelegationMatchContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/domain/matching/DoubleMatchContext.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/domain/matching/DoubleMatchContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/domain/matching/SingleMatchContext.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/domain/matching/SingleMatchContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/domain/matching/package-info.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/domain/matching/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/domain/package-info.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/domain/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/index/Indexer.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/index/Indexer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/index/package-info.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/index/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/package-info.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/parser/AbstractArtifactClusionAdder.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/parser/AbstractArtifactClusionAdder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/parser/AbstractClusionAdder.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/parser/AbstractClusionAdder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/parser/AbstractModuleClusionAdder.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/parser/AbstractModuleClusionAdder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/parser/ClusionAdder.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/parser/ClusionAdder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/parser/ModulesDescriptorBuilder.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/parser/ModulesDescriptorBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/parser/ModulesXmlLocator.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/parser/ModulesXmlLocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/parser/ModulesXmlParser.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/parser/ModulesXmlParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/parser/package-info.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/parser/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/xml/ModuleXmlBuilder.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/xml/ModuleXmlBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/xml/XmlFragmentParser.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/xml/XmlFragmentParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/xml/package-info.java
+++ b/smartics-jboss-modules-maven-plugin/src/main/java/de/smartics/maven/plugin/jboss/modules/xml/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/main/resources/xsd/jboss-modules-descriptor.xsd
+++ b/smartics-jboss-modules-maven-plugin/src/main/resources/xsd/jboss-modules-descriptor.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+    Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/test/java/de/smartics/maven/plugin/jboss/modules/domain/ModuleMapCreateNameTest.java
+++ b/smartics-jboss-modules-maven-plugin/src/test/java/de/smartics/maven/plugin/jboss/modules/domain/ModuleMapCreateNameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/test/java/help/de/smartics/maven/plugin/jboss/modules/ArtifactBuilder.java
+++ b/smartics-jboss-modules-maven-plugin/src/test/java/help/de/smartics/maven/plugin/jboss/modules/ArtifactBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/test/java/help/de/smartics/maven/plugin/jboss/modules/ClusionBuilder.java
+++ b/smartics-jboss-modules-maven-plugin/src/test/java/help/de/smartics/maven/plugin/jboss/modules/ClusionBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/test/java/help/de/smartics/maven/plugin/jboss/modules/ModuleDescriptorBuilder.java
+++ b/smartics-jboss-modules-maven-plugin/src/test/java/help/de/smartics/maven/plugin/jboss/modules/ModuleDescriptorBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/test/java/test/de/smartics/maven/plugin/jboss/modules/parser/AbstractModulesXmlParserTest.java
+++ b/smartics-jboss-modules-maven-plugin/src/test/java/test/de/smartics/maven/plugin/jboss/modules/parser/AbstractModulesXmlParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/test/java/test/de/smartics/maven/plugin/jboss/modules/parser/ModulesXmlParserApplyToModuleXmlTest.java
+++ b/smartics-jboss-modules-maven-plugin/src/test/java/test/de/smartics/maven/plugin/jboss/modules/parser/ModulesXmlParserApplyToModuleXmlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/test/java/test/de/smartics/maven/plugin/jboss/modules/parser/ModulesXmlParserApplyToModuleXmlWithSystemTest.java
+++ b/smartics-jboss-modules-maven-plugin/src/test/java/test/de/smartics/maven/plugin/jboss/modules/parser/ModulesXmlParserApplyToModuleXmlWithSystemTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/test/java/test/de/smartics/maven/plugin/jboss/modules/parser/ModulesXmlParserDependenciesFullXmlTest.java
+++ b/smartics-jboss-modules-maven-plugin/src/test/java/test/de/smartics/maven/plugin/jboss/modules/parser/ModulesXmlParserDependenciesFullXmlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/test/java/test/de/smartics/maven/plugin/jboss/modules/parser/ModulesXmlParserDependenciesXmlTest.java
+++ b/smartics-jboss-modules-maven-plugin/src/test/java/test/de/smartics/maven/plugin/jboss/modules/parser/ModulesXmlParserDependenciesXmlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/test/java/test/de/smartics/maven/plugin/jboss/modules/parser/ModulesXmlParserDirectivesXmlTest.java
+++ b/smartics-jboss-modules-maven-plugin/src/test/java/test/de/smartics/maven/plugin/jboss/modules/parser/ModulesXmlParserDirectivesXmlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/test/java/test/de/smartics/maven/plugin/jboss/modules/parser/ModulesXmlParserMatchXmlTest.java
+++ b/smartics-jboss-modules-maven-plugin/src/test/java/test/de/smartics/maven/plugin/jboss/modules/parser/ModulesXmlParserMatchXmlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+ * Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/test/resources/test/de/smartics/maven/plugin/jboss/modules/parser/apply-to-module-with-system.xml
+++ b/smartics-jboss-modules-maven-plugin/src/test/resources/test/de/smartics/maven/plugin/jboss/modules/parser/apply-to-module-with-system.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+    Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/test/resources/test/de/smartics/maven/plugin/jboss/modules/parser/apply-to-module.xml
+++ b/smartics-jboss-modules-maven-plugin/src/test/resources/test/de/smartics/maven/plugin/jboss/modules/parser/apply-to-module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+    Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/test/resources/test/de/smartics/maven/plugin/jboss/modules/parser/dependencies-full.xml
+++ b/smartics-jboss-modules-maven-plugin/src/test/resources/test/de/smartics/maven/plugin/jboss/modules/parser/dependencies-full.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+    Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/test/resources/test/de/smartics/maven/plugin/jboss/modules/parser/dependencies.xml
+++ b/smartics-jboss-modules-maven-plugin/src/test/resources/test/de/smartics/maven/plugin/jboss/modules/parser/dependencies.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+    Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/test/resources/test/de/smartics/maven/plugin/jboss/modules/parser/directives.xml
+++ b/smartics-jboss-modules-maven-plugin/src/test/resources/test/de/smartics/maven/plugin/jboss/modules/parser/directives.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+    Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/test/resources/test/de/smartics/maven/plugin/jboss/modules/parser/full-and-everything.xml
+++ b/smartics-jboss-modules-maven-plugin/src/test/resources/test/de/smartics/maven/plugin/jboss/modules/parser/full-and-everything.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+    Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/test/resources/test/de/smartics/maven/plugin/jboss/modules/parser/match-regular.xml
+++ b/smartics-jboss-modules-maven-plugin/src/test/resources/test/de/smartics/maven/plugin/jboss/modules/parser/match-regular.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+    Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/smartics-jboss-modules-maven-plugin/src/test/resources/test/de/smartics/maven/plugin/jboss/modules/parser/match.xml
+++ b/smartics-jboss-modules-maven-plugin/src/test/resources/test/de/smartics/maven/plugin/jboss/modules/parser/match.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2014 smartics, Kronseder & Reiner GmbH
+    Copyright 2013-2015 smartics, Kronseder & Reiner GmbH
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
Cross ref https://github.com/wildfly-extras/wildfly-camel/issues/405.

Merge of upstream smartics changes for supporting Maven 3.2.5+. I verified that this change works for Maven 3.2.x and 3.3.x.