### PR TITLE
Adding graph filters

### DIFF
--- a/maven-graph-plugin/src/main/java/org/fusesource/mvnplugins/graph/DependencyVisualizer.java
+++ b/maven-graph-plugin/src/main/java/org/fusesource/mvnplugins/graph/DependencyVisualizer.java
@@ -24,6 +24,7 @@ import org.codehaus.plexus.util.cli.*;
 import org.codehaus.plexus.util.FileUtils;
 
 import java.util.*;
+import java.util.regex.Pattern;
 import java.io.File;
 import java.io.PrintStream;
 
@@ -48,6 +49,10 @@ public class DependencyVisualizer {
     Log log;
     boolean cascade;
     String direction="TB";
+    Pattern excludeGroupIds;
+    Pattern includeGroupIds;
+    Pattern excludeArtifactIds;
+    Pattern includeArtifactIds;
     
     Set<String> excludeGroupIds = new HashSet<String>();
     Set<String> includeGroupIds = new HashSet<String>();
@@ -87,6 +92,20 @@ public class DependencyVisualizer {
             if( hideExternal && roots == 0 ) {
                 return true;
             }
+            
+            if( excludeGroupIds != null && excludeGroupIds.matcher(artifact.getGroupId()).matches() ) {
+            	return true;
+            }
+            if( includeGroupIds != null && !includeGroupIds.matcher(artifact.getGroupId()).matches() ) {
+            	return true;
+            }
+            if( excludeArtifactIds != null && excludeArtifactIds.matcher(artifact.getArtifactId()).matches() ) {
+            	return true;
+            }
+            if( includeArtifactIds != null && !includeArtifactIds.matcher(artifact.getArtifactId()).matches() ) {
+            	return true;
+            }
+            
             return false;
         }
 
@@ -399,7 +418,7 @@ public class DependencyVisualizer {
         }
         if (dn.hasChildren()) {
             for (DependencyNode c : (List<DependencyNode>) dn.getChildren()) {
-               Node child = add(c, false);
+                Node child = add(c, false);
                 Edge edge = new Edge(parent, child, c);
                 add(edge);
             }

--- a/maven-graph-plugin/src/main/java/org/fusesource/mvnplugins/graph/ProjectMojo.java
+++ b/maven-graph-plugin/src/main/java/org/fusesource/mvnplugins/graph/ProjectMojo.java
@@ -30,7 +30,6 @@ import org.apache.maven.shared.dependency.tree.DependencyTreeBuilderException;
 import org.apache.maven.shared.dependency.tree.DependencyNode;
 
 import java.util.ArrayList;
-import java.util.regex.Pattern;
 import java.io.File;
 
 /**
@@ -186,6 +185,23 @@ public class ProjectMojo extends AbstractMojo {
     protected String excludeGroupIds;
 
     /**
+     * A comma separated list of artifact Ids to include. If this parameter
+     * is specified, any artifact Id not matching will  be excluded.
+     * A '*' can be appended <b>only</b> at the end to match subgroups<br/>
+     * For example: <code>commons-*</code>
+     * @parameter expression="${include-artifact-ids}"
+     */
+    protected String includeArtifactIds;
+    
+    /**
+     * A comma separated list of artifact Ids to exclude. A '*' can be appended
+     * <b>only</b> at the end to match subgroups<br/>
+     * For example: <code>commons-*</code>
+     * @parameter expression="${exclude-artifact-ids}"
+     */
+    protected String excludeArtifactIds;
+
+    /**
      * If set to true then the module type label will not be drawn.
      * <br/>
      * @parameter default-value="false" expression="${hide-type}"
@@ -214,30 +230,6 @@ public class ProjectMojo extends AbstractMojo {
      * @parameter default-value="true" expression="${graph.cascade}"
      */
     protected boolean cascade;
-
-    /**
-     * A regex pattern that will be applied to exclude the given group ids.
-     * @parameter expression="${exclude-groupIds}"
-     */
-    protected String excludeGroupIds;
-
-    /**
-     * A regex pattern that will be applied to include only the given group ids.
-     * @parameter expression="${include-groupIds}"
-     */
-    protected String includeGroupIds;
-
-    /**
-     * A regex pattern that will be applied to exclude the given artifact ids.
-     * @parameter expression="${exclude-artifactIds}"
-     */
-    protected String excludeArtifactIds;
-
-    /**
-     * A regex pattern that will be applied to include only the given artifact ids.
-     * @parameter expression="${include-artifactIds}"
-     */
-    protected String includeArtifactIds;
 
     /**
      * The direction that the graph will be laid out in.
@@ -287,19 +279,18 @@ public class ProjectMojo extends AbstractMojo {
                }
             }
             
-            if( excludeGroupIds != null ) {
-            	visualizer.excludeGroupIds = Pattern.compile(excludeGroupIds);
+            if (excludeArtifactIds != null) {
+               for (String artifactId : excludeArtifactIds.split(",")) {
+                  visualizer.excludeArtifactIds.add(artifactId.trim());
+               }
             }
-            if( includeGroupIds != null ) {
-            	visualizer.includeGroupIds = Pattern.compile(includeGroupIds);
+            
+            if (includeArtifactIds != null) {
+               for (String artifactId : includeArtifactIds.split(",")) {
+                  visualizer.includeArtifactIds.add(artifactId.trim());
+               }
             }
-            if( excludeArtifactIds != null ) {
-            	visualizer.excludeArtifactIds = Pattern.compile(excludeArtifactIds);
-            }
-            if( includeArtifactIds != null ) {
-            	visualizer.includeArtifactIds = Pattern.compile(includeArtifactIds);
-            }
-
+            
             ArrayList<MavenProject> projects = new ArrayList<MavenProject>();
             collectProjects(projects);
 

--- a/maven-graph-plugin/src/main/java/org/fusesource/mvnplugins/graph/ProjectMojo.java
+++ b/maven-graph-plugin/src/main/java/org/fusesource/mvnplugins/graph/ProjectMojo.java
@@ -30,6 +30,7 @@ import org.apache.maven.shared.dependency.tree.DependencyTreeBuilderException;
 import org.apache.maven.shared.dependency.tree.DependencyNode;
 
 import java.util.ArrayList;
+import java.util.regex.Pattern;
 import java.io.File;
 
 /**
@@ -166,7 +167,7 @@ public class ProjectMojo extends AbstractMojo {
      * @parameter default-value="false" expression="${hide-group-id}"
      */
     protected boolean hideGroupId;
-    
+
     /**
      * A comma separated list of group Ids to include. If this parameter
      * is specified, any group Id not matching will  be excluded.
@@ -215,6 +216,30 @@ public class ProjectMojo extends AbstractMojo {
     protected boolean cascade;
 
     /**
+     * A regex pattern that will be applied to exclude the given group ids.
+     * @parameter expression="${exclude-groupIds}"
+     */
+    protected String excludeGroupIds;
+
+    /**
+     * A regex pattern that will be applied to include only the given group ids.
+     * @parameter expression="${include-groupIds}"
+     */
+    protected String includeGroupIds;
+
+    /**
+     * A regex pattern that will be applied to exclude the given artifact ids.
+     * @parameter expression="${exclude-artifactIds}"
+     */
+    protected String excludeArtifactIds;
+
+    /**
+     * A regex pattern that will be applied to include only the given artifact ids.
+     * @parameter expression="${include-artifactIds}"
+     */
+    protected String includeArtifactIds;
+
+    /**
      * The direction that the graph will be laid out in.
      * it can be one of the following values:
      * <br/>
@@ -260,6 +285,19 @@ public class ProjectMojo extends AbstractMojo {
                for (String groupId : includeGroupIds.split(",")) {
                   visualizer.includeGroupIds.add(groupId.trim());
                }
+            }
+            
+            if( excludeGroupIds != null ) {
+            	visualizer.excludeGroupIds = Pattern.compile(excludeGroupIds);
+            }
+            if( includeGroupIds != null ) {
+            	visualizer.includeGroupIds = Pattern.compile(includeGroupIds);
+            }
+            if( excludeArtifactIds != null ) {
+            	visualizer.excludeArtifactIds = Pattern.compile(excludeArtifactIds);
+            }
+            if( includeArtifactIds != null ) {
+            	visualizer.includeArtifactIds = Pattern.compile(includeArtifactIds);
             }
 
             ArrayList<MavenProject> projects = new ArrayList<MavenProject>();

--- a/maven-graph-plugin/src/main/java/org/fusesource/mvnplugins/graph/ProjectReportMojo.java
+++ b/maven-graph-plugin/src/main/java/org/fusesource/mvnplugins/graph/ProjectReportMojo.java
@@ -94,9 +94,6 @@ public class ProjectReportMojo extends ProjectMojo implements MavenReport {
     public void generate(Sink sink, Locale locale) throws MavenReportException {
         try {
             getLog().info(project.getModules().toString() );
-            if( project.getModules().size() > 1 && reactorProjects != null ) {
-                hideExternal = true;
-            }
             execute();
             
             sink.figure();


### PR DESCRIPTION
Hi,

I've added filters to the maven-graph-plugins:
  - excludeGroupIds
  - includeGroupIds
  - excludeArtifactsIds
  - excludeArtifactsIds

The 4 new parameters are regex expressions which are applied to the groupId and artifactId. 
The exclusion pattern has precedence over the inclusion pattern (per convention)

Let me know if you see any issue with the work.
