### PR TITLE
fix minor regression introduced in #4: trim scope ids as before

### DIFF
--- a/maven-graph-plugin/src/main/java/org/fusesource/mvnplugins/graph/ProjectMojo.java
+++ b/maven-graph-plugin/src/main/java/org/fusesource/mvnplugins/graph/ProjectMojo.java
@@ -263,7 +263,7 @@ public class ProjectMojo extends AbstractMojo {
 
             if (hideScopes != null) {
                 for (String scope : hideScopes.split(",")) {
-                    visualizer.hideScopes.add(scope);
+                    visualizer.hideScopes.add(scope.trim());
                 }
             }
             


### PR DESCRIPTION
Restore previous behaviour when splitting hide-scope ids.