### PR TITLE
Cache child count in maven-graph-plugin

### DIFF
--- a/maven-graph-plugin/src/main/java/org/fusesource/mvnplugins/graph/DependencyVisualizer.java
+++ b/maven-graph-plugin/src/main/java/org/fusesource/mvnplugins/graph/DependencyVisualizer.java
@@ -66,6 +66,7 @@ public class DependencyVisualizer {
         private final ArrayList<Edge> parents = new ArrayList<Edge>();
         private final Artifact artifact;
         private int roots;
+        private int recursiveChildCount = -1;
 
         public Node(String id, Artifact artifact) {
             this.id = id;
@@ -202,6 +203,11 @@ public class DependencyVisualizer {
         }
 
         public int getRecursiveChildCount() {
+
+            if (recursiveChildCount >= 0) {
+                return recursiveChildCount;
+            }
+
             int rc = children.size();
             for (Edge child : children) {
                 int t = child.getRecursiveChildCount();
@@ -209,6 +215,7 @@ public class DependencyVisualizer {
                     rc = t;
                 }
             }
+            recursiveChildCount = rc;
             return rc;
         }
 


### PR DESCRIPTION
Currently, the recursiveChildCount is not cached and this calculation is
run everytime.  It is likely the weight calculation algorithm is being
exponential in time complexity.  By caching the recursiveChildCount,
this intractability problem is solved.