### PR TITLE
https to be used for repositories in pom.xml files

### DIFF
--- a/fusesource-pom/pom.xml
+++ b/fusesource-pom/pom.xml
@@ -365,14 +365,14 @@
         <repository>
           <id>fusesource-releases</id>
           <name>FuseSource Release Repository</name>
-          <url>http://repo.fusesource.com/nexus/content/groups/public</url>
+          <url>https://repo.fusesource.com/nexus/content/groups/public</url>
           <releases><enabled>true</enabled></releases>
           <snapshots><enabled>false</enabled></snapshots>
         </repository>
         <repository>
           <id>fusesource-snapshots</id>
           <name>FuseSource Snapshot Repository</name>
-          <url>http://repo.fusesource.com/nexus/content/groups/public-snapshots</url>
+          <url>https://repo.fusesource.com/nexus/content/groups/public-snapshots</url>
           <releases><enabled>false</enabled></releases>
           <snapshots><enabled>true</enabled></snapshots>
         </repository>
@@ -381,14 +381,14 @@
         <pluginRepository>
           <id>fusesource-releases</id>
           <name>FuseSource Release Repository</name>
-          <url>http://repo.fusesource.com/nexus/content/groups/public</url>
+          <url>https://repo.fusesource.com/nexus/content/groups/public</url>
           <releases><enabled>true</enabled></releases>
           <snapshots><enabled>false</enabled></snapshots>
         </pluginRepository>
         <pluginRepository>
           <id>fusesource-snapshots</id>
           <name>FuseSource Snapshot Repository</name>
-          <url>http://repo.fusesource.com/nexus/content/groups/public-snapshots</url>
+          <url>https://repo.fusesource.com/nexus/content/groups/public-snapshots</url>
           <releases><enabled>false</enabled></releases>
           <snapshots><enabled>true</enabled></snapshots>
         </pluginRepository>
@@ -402,14 +402,14 @@
         <repository>
           <id>fusesource-proxy</id>
           <name>FuseSource Proxy Repository</name>
-          <url>http://repo.fusesource.com/nexus/content/groups/m2-proxy</url>
+          <url>https://repo.fusesource.com/nexus/content/groups/m2-proxy</url>
         </repository>
       </repositories>
       <pluginRepositories>
         <pluginRepository>
           <id>fusesource-proxy</id>
           <name>FuseSource Proxy Repository</name>
-          <url>http://repo.fusesource.com/nexus/content/groups/m2-proxy</url>
+          <url>https://repo.fusesource.com/nexus/content/groups/m2-proxy</url>
         </pluginRepository>
       </pluginRepositories>
     </profile>  

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
     <site>
       <id>website.fusesource.org</id>
       <name>website</name>
-      <url>dav:http://fusesource.com/forge/dav/${forge-project-id}/maven/${project.version}</url>
+      <url>dav:https://fusesource.com/forge/dav/${forge-project-id}/maven/${project.version}</url>
     </site>
   </distributionManagement> 
 
@@ -270,13 +270,13 @@
 
         <repository>
           <id>fluido-skin</id>
-          <url>http://fluido-skin.googlecode.com/svn/repo/</url>
+          <url>https://fluido-skin.googlecode.com/svn/repo/</url>
         </repository>
         
         <repository>
           <id>scala-tools.org</id>
           <name>Scala-tools Maven2 Repository</name>
-          <url>http://scala-tools.org/repo-releases</url>
+          <url>https://scala-tools.org/repo-releases</url>
           <releases>
             <enabled>true</enabled>
           </releases>
@@ -291,7 +291,7 @@
         <pluginRepository>
           <id>scala</id>
           <name>Scala Tools</name>
-          <url>http://scala-tools.org/repo-releases</url>
+          <url>https://scala-tools.org/repo-releases</url>
           <releases>
             <enabled>true</enabled>
           </releases>

--- a/scala-mojo-support/src/it/test-mojo-project/pom.xml
+++ b/scala-mojo-support/src/it/test-mojo-project/pom.xml
@@ -86,14 +86,14 @@
 		<repository>
 			<id>scala-tools.org</id>
 			<name>Scala-tools Maven2 Repository</name>
-			<url>http://scala-tools.org/repo-releases</url>
+			<url>https://scala-tools.org/repo-releases</url>
 		</repository>
 	</repositories>
 	<pluginRepositories>
 		<pluginRepository>
 			<id>scala-tools.org</id>
 			<name>Scala-tools Maven2 Repository</name>
-			<url>http://scala-tools.org/repo-releases</url>
+			<url>https://scala-tools.org/repo-releases</url>
 		</pluginRepository>
 	</pluginRepositories>
 

--- a/smartics-jboss-modules-maven-plugin/pom.xml
+++ b/smartics-jboss-modules-maven-plugin/pom.xml
@@ -417,7 +417,7 @@
         <repositories>
           <repository>
             <id>smartics</id>
-            <url>http://www.smartics.eu/nexus/content/groups/public-group</url>
+            <url>https://www.smartics.eu/nexus/content/groups/public-group</url>
             <releases>
               <enabled>true</enabled>
             </releases>
@@ -429,7 +429,7 @@
         <pluginRepositories>
           <pluginRepository>
             <id>smartics</id>
-            <url>http://www.smartics.eu/nexus/content/groups/public-group</url>
+            <url>https://www.smartics.eu/nexus/content/groups/public-group</url>
             <releases>
               <enabled>true</enabled>
             </releases>


### PR DESCRIPTION
Context: Effort to ensure that components on which WildFly rely only download/upload maven artifacts using https.

JIra: https://issues.jboss.org/browse/MVNPLUGINS-5

I found some references to http repositories. I did it blindly, so feel free to correct if you don't think these changes are required.

Thanks.