### PR TITLE
ENTESB-12239: Fuse Distribution fails to build in MEAD_Simulator tooling

### DIFF
--- a/maven-notices-plugin/src/main/java/org/fusesource/mvnplugins/notices/util/DependencyPom.java
+++ b/maven-notices-plugin/src/main/java/org/fusesource/mvnplugins/notices/util/DependencyPom.java
@@ -148,6 +148,7 @@ public class DependencyPom {
                 request.setDebug(true);
             }
             request.setOffline(session.getRequest().isOffline());
+            request.setProperties(session.getUserProperties());
 
             PrintStream invokerLog = null;
             InvocationResult invocationResult = null; 

--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,11 @@
                     <additionalparam>${javadoc.opts}</additionalparam>
                 </configuration>
             </plugin>
+            <plugin>
+            	<groupId>org.apache.maven.plugins</groupId>
+            	<artifactId>maven-source-plugin</artifactId>
+            	<version>3.2.0</version>
+            </plugin>
         </plugins>
     </pluginManagement>
     
@@ -168,6 +173,20 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
         <version>2.5.1</version>
+      </plugin>
+      
+      <plugin>
+      	<groupId>org.apache.maven.plugins</groupId>
+      	<artifactId>maven-source-plugin</artifactId>
+      	<executions>
+      		<execution>
+      			<id>attach-sources</id>
+      			<phase>verify</phase>
+      			<goals>
+      				<goal>jar-no-fork</goal>
+      			</goals>
+      		</execution>
+      	</executions>
       </plugin>
 
     </plugins>


### PR DESCRIPTION
* Pass user properties to invocation of maven-notices-plugin
* Add source jar generation.